### PR TITLE
v0.2.0: token-weighted costs and quiet-by-default UX

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,217 @@
+# AGENTS.md
+
+## Project Overview
+
+Pyramid is a Copilot CLI plugin implementing a Mixture-of-Agents (MoA) router
+that dispatches each subtask to the cheapest capable solver tier and escalates
+only when verification confidence is low. Escalation is governed by the
+Hansen–Zilberstein Value-of-Computation rule. The plugin ships four agents
+(three solver tiers + one verifier), four orchestration skills, and a single
+`/pyramid:pyramid` slash command.
+
+## Repository Layout
+
+```
+pyramid-moa/
+├── agents/
+│   ├── tier1-fast.agent.md
+│   ├── tier2-mid.agent.md
+│   ├── tier3-deep.agent.md
+│   └── pyramid-verifier.agent.md
+├── skills/
+│   ├── pyramid-orchestrate/SKILL.md
+│   ├── pyramid-decompose/SKILL.md
+│   ├── pyramid-verify/SKILL.md
+│   └── pyramid-aggregate/SKILL.md
+├── commands/
+│   └── pyramid.md
+├── docs/
+│   └── benchmarks/
+│       ├── tasks.md            # Standard benchmark suite
+│       └── baseline-metrics.md # Most-recent benchmark run + diffs
+├── plugin.json                 # Manifest (current: 0.2.0)
+├── README.md
+├── AGENTS.md                   # This file
+├── CHANGELOG.md
+└── LICENSE                     # MIT
+```
+
+## Installation & Usage
+
+```
+copilot plugin install tonybaloney/pyramid
+/pyramid:pyramid <task description> [flags]
+```
+
+See `README.md` for the full flag reference.
+
+## Build / Test / Lint
+
+This is a **declarative plugin** — Markdown + JSON only. There is no
+compilation, package manager, or test runner.
+
+- Validate `plugin.json` with any JSON parser before committing.
+- Validate the YAML frontmatter at the top of every `*.agent.md` and
+  `SKILL.md`.
+- Validate fenced ` ```pyramid-* ` JSON blocks by running a representative
+  benchmark task through `/pyramid:pyramid --output=debug` and inspecting
+  the report file under `~/.copilot/session-state/<id>/files/pyramid-runs/`.
+- The benchmark suite under `docs/benchmarks/tasks.md` is the closest thing
+  to a test harness; re-run it after non-trivial changes and update
+  `docs/benchmarks/baseline-metrics.md`.
+
+## Conventions
+
+### Frontmatter
+
+Every agent and skill markdown file begins with YAML frontmatter:
+
+```yaml
+---
+name: <kebab-case-id>
+description: <one sentence>
+tools: [optional, list]
+---
+```
+
+### Output contracts (strict JSON, fenced)
+
+| Block               | Producer               | Required fields                                                                 |
+|---------------------|------------------------|--------------------------------------------------------------------------------|
+| `pyramid-dag`       | `pyramid-decompose`    | `task`, `nodes[]` (`id`, `kind`, `description`, `difficulty_prior`, `dependencies`, `success_criteria`) |
+| `pyramid-result`    | tier-1 / tier-2 / tier-3 solvers | `subtask_id`, `answer`, `self_confidence` (0.0–1.0), `blocked_reason` (or null) |
+| `pyramid-verdict`   | `pyramid-verifier`     | `subtask_id`, `confidence`, `issues[]`, `would_benefit_from_escalation`, `evidence` |
+| `pyramid-decision`  | `pyramid-verify`       | `subtask_id`, `verifier_confidence`, `verifier_issues[]`, `decision`, `next_tier`, `reason`, `estimated_cost_used`, `cost_breakdown` |
+
+These schemas are load-bearing. Solver outputs are **captured by the
+orchestrator, not surfaced to the user** — at the default
+`--output=quiet`, the user sees only a 2-line summary. Do not weaken the
+JSON contracts to make terminal output prettier; render the report file
+instead.
+
+### Confidence calibration anchors (verifier)
+
+| Confidence | Meaning |
+|------------|---------|
+| 0.95 | Verifiably correct (independent check passes) |
+| 0.80 | Looks correct, no contradictions found |
+| 0.55 | Plausible but one concrete concern (edge case, untested) |
+| 0.30 | Likely buggy or partially blocked |
+| 0.10 | Clearly wrong or empty |
+
+### Cost units (v0.2.0 token-weighted)
+
+```
+cost(call) = (input_tokens + output_tokens) * multiplier(model)
+```
+
+| Model              | Multiplier |
+|--------------------|------------|
+| claude-haiku-4.5   | 0.33       |
+| claude-sonnet-4.6  | 1.00       |
+| claude-opus-4.7    | 7.00       |
+
+`--budget` and all ledger totals are in token-weighted units (`tw-units`).
+When the underlying `task` tool does not surface token counts, fall back
+to `len(prompt + answer) / 4` and mark the trace entry `cost_estimated:
+true` (a `⚠` line is shown to the user).
+
+### Thresholds, priors, and anchoring
+
+- Default escalation thresholds: **θ₁ = 0.75, θ₂ = 0.85**.
+- Default `value_of_correctness`: **8** (re-tuned in 0.2.0; was 10).
+- `P_correct(N+1 | N wrong)`: tier1→2 = 0.55, tier2→3 = 0.45.
+- Difficulty priors come from the heuristic table in
+  `skills/pyramid-decompose/`. Tune per-task; do not change the defaults
+  without justification in the PR and a re-benchmark.
+- **Anchoring is OFF by default.** Per the paper (§4), passing *incorrect*
+  lower-tier reasoning to a higher tier degrades accuracy by up to **−18 pp**.
+  Correct lower-tier reasoning improves it by **+19 pp**, but we cannot
+  reliably tell them apart at escalation time.
+
+### Per-run trace and report
+
+Every non-dry-run invocation writes two paired files:
+
+- `<session>/files/pyramid-runs/<task-slug>-<YYYYMMDD-HHMMSS>.json` — the
+  structured trace (single source of truth for metrics).
+- `<session>/files/pyramid-runs/<task-slug>-<YYYYMMDD-HHMMSS>.md` — the
+  human-readable report.
+
+The terminal shows only what `--output` selects; the trace and report are
+always written.
+
+## Agent Roster
+
+### `tier1-fast` (default model: `claude-haiku-4.5`, multiplier 0.33)
+
+- **Role:** First-pass solver for low-to-moderate difficulty subtasks.
+- **Invoked when:** `pick_initial_tier` selects tier 1 (difficulty_prior ≤ 0.70).
+- **Must NOT:** expand scope, invent dependencies, attempt architecture-level
+  work, or fake high `self_confidence`. Report `self_confidence ≤ 0.30` and a
+  `blocked_reason` when out of depth — that is how escalation is triggered.
+
+### `tier2-mid` (default model: `claude-sonnet-4.6`, multiplier 1.00)
+
+- **Role:** Multi-step reasoning, light refactoring, moderate ambiguity.
+- **Invoked when:** tier 1 is rejected by `pyramid-verify`, or when
+  `difficulty_prior > 0.70` causes the orchestrator to skip tier 1.
+- **Must NOT:** redo work already accepted from upstream subtasks; treat
+  the verifier critique as the contract, not a suggestion.
+
+### `tier3-deep` (default model: `claude-opus-4.7`, multiplier 7.00)
+
+- **Role:** Final escalation tier — hardest subtasks where lower tiers
+  failed verification.
+- **Invoked when:** tier 2 is rejected and `max_tier ≥ 3`.
+- **Must NOT:** be invoked speculatively. Tier-3 dispatch is expensive
+  (~21× tier-1 per token) and only justified when the VoC test in
+  `pyramid-verify` passes.
+
+### `pyramid-verifier` (default model: `claude-haiku-4.5`, multiplier 0.33)
+
+- **Role:** Strict-JSON verifier; emits a calibrated `pyramid-verdict` for
+  a tier output.
+- **Invoked when:** After every tier solver call, by `pyramid-verify`.
+- **Must NOT:** attempt to solve the subtask itself, rewrite the answer,
+  or call other tiers.
+
+## Skill Roster
+
+| Skill                | Purpose |
+|----------------------|---------|
+| `pyramid-orchestrate`| Main control loop: decompose → dispatch → verify → escalate → aggregate. Owns the per-run JSON trace. |
+| `pyramid-decompose`  | Produce the `pyramid-dag` JSON of subtasks with difficulty priors. |
+| `pyramid-verify`     | Wrap the verifier call and apply the Hansen–Zilberstein VoC rule (token-weighted). |
+| `pyramid-aggregate`  | Merge per-subtask results, write the Markdown report file, and print the terminal summary at the configured verbosity. |
+
+## Adding a New Agent or Skill
+
+1. Create `agents/<name>.agent.md` or `skills/<name>/SKILL.md` with valid
+   YAML frontmatter.
+2. If the agent emits structured output, define and document its fenced
+   `pyramid-*` block schema alongside the existing ones in this file.
+3. Register the file in `plugin.json` if the manifest enumerates agents/skills.
+4. Update `README.md` and the relevant roster section in this `AGENTS.md`.
+5. Add at least one task that exercises the new agent/skill to
+   `docs/benchmarks/tasks.md` and re-run the benchmark.
+6. Smoke-test by running a representative task through `/pyramid:pyramid
+   --output=debug` and confirming the new agent/skill is invoked and its
+   output parses.
+
+## Prompt Style for Tier and Verifier Prompts
+
+- **Imperative voice.** "Return the JSON block." not "You could return…".
+- **Inline the schema** every time, even if the agent has seen it before.
+  Sub-agents are stateless across invocations.
+- **Never instruct a sub-agent to call `/pyramid:pyramid` recursively.** Use
+  the underlying skills (`pyramid-decompose`, `pyramid-verify`, etc.) directly.
+- **Anchoring discipline:** When passing context on escalation, follow
+  `pyramid-orchestrate`'s rule — include the rejected answer only if
+  `anchor == true`.
+- **Mitigations over heroics:** prefer reporting a low `self_confidence` with
+  a clear `blocked_reason` over guessing.
+
+## License
+
+MIT — see `LICENSE`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,55 @@
+# Changelog
+
+All notable changes to this plugin are documented here.
+
+## 0.2.0 — token-weighted costs and quiet UX
+
+### Breaking
+
+- **Cost model replaced.** All cost accounting (`--budget`, ledger totals,
+  savings, `pyramid-decision.estimated_cost_used`) is now in
+  **token-weighted units** (`tw-units`):
+  `cost(call) = (input_tokens + output_tokens) * multiplier(model)`.
+  Multipliers — Haiku 0.33, Sonnet 1.00, Opus 7.00 — replace the legacy flat
+  ordinals 1 / 5 / 25. The new Haiku:Sonnet:Opus ratio is `1 : 3 : 21` (was
+  `1 : 5 : 25`). GPT-track multipliers are placeholder pending confirmation.
+- **`--budget` units changed.** Previously documented as USD but always
+  operated on ordinal units; now explicitly tw-units.
+- **Default verbosity changed.** `--output=quiet` is now the default; v0.1.0
+  behavior is reproducible with `--output=debug`.
+- **`pyramid-decision` schema gained `cost_breakdown`.** Consumers parsing
+  the block must accept the new field; required fields unchanged.
+
+### Added
+
+- `--output=quiet|normal|debug` flag on `/pyramid:pyramid`.
+- `--value-of-correctness=<float>` flag (default re-tuned from `10` to `8`).
+- Per-run JSON trace at
+  `<session>/files/pyramid-runs/<task-slug>-<YYYYMMDD-HHMMSS>.json`
+  capturing tokens, costs, latencies, verdicts, and totals.
+- Per-run human-readable Markdown report at the same stem with a `.md`
+  extension. Always written, regardless of `--output`.
+- `AGENTS.md` documenting conventions, agent roster, and skill roster.
+- `CHANGELOG.md` (this file).
+- `docs/benchmarks/tasks.md` — standard 12-task benchmark suite.
+- `docs/benchmarks/baseline-metrics.md` — most-recent measurements,
+  before/after comparisons, and acceptance gates.
+
+### Changed
+
+- Default `value_of_correctness` lowered to `8` to reflect the smaller
+  Haiku:Sonnet:Opus cost ratio under the new token-weighted model.
+- `pyramid-aggregate` now owns the report-file write; the orchestrator
+  owns the trace-file write.
+- `⚠` warnings (max-tier-without-accept, malformed solver output,
+  estimated token counts) are surfaced even at `--output=quiet`.
+
+### Notes
+
+- No behavior change to anchoring (default remains `off`; paper §4).
+- The underlying VoC algorithm and θ defaults are unchanged.
+
+## 0.1.0 — initial release
+
+- Three solver tiers + verifier, four orchestration skills, single slash
+  command. Ordinal cost units. Verbose terminal output by default.

--- a/README.md
+++ b/README.md
@@ -46,13 +46,52 @@ command for this plugin is `/pyramid:pyramid` (not `/pyramid`).
 
 ### Flags
 
-| Flag         | Default          | Description                                                                |
-|--------------|------------------|----------------------------------------------------------------------------|
-| `--track`    | `claude`         | Model family: `claude`, `gpt`, or `mixed`.                                 |
-| `--theta`    | `0.75,0.85`      | Confidence thresholds θ₁,θ₂ for escalating from tier 1→2 and 2→3.          |
-| `--max-tier` | `3`              | Hard ceiling on escalation.                                                |
-| `--anchor`   | `off`            | If `on`, pass the rejected lower-tier answer to higher tiers as context.   |
-| `--budget`   | (none)           | Optional cost cap (relative units) — stops further escalation when hit.    |
+| Flag                      | Default          | Description                                                                |
+|---------------------------|------------------|----------------------------------------------------------------------------|
+| `--track`                 | `claude`         | Model family: `claude`, `gpt`, or `mixed`.                                 |
+| `--theta`                 | `0.75,0.85`      | Confidence thresholds θ₁,θ₂ for escalating from tier 1→2 and 2→3.          |
+| `--max-tier`              | `3`              | Hard ceiling on escalation.                                                |
+| `--anchor`                | `off`            | If `on`, pass the rejected lower-tier answer to higher tiers as context.   |
+| `--budget`                | (none)           | Cost cap in **token-weighted units** (tw-units). Stops escalation when hit. |
+| `--dry-run`               | `off`            | Print the DAG and planned tiers without dispatching.                       |
+| `--output`                | `quiet`          | Terminal verbosity: `quiet`, `normal`, or `debug`. **New default in 0.2.0**. |
+| `--value-of-correctness`  | `8`              | VoC scaling factor (was `10` pre-0.2.0; re-tuned for token-weighted costs).|
+
+### Output verbosity
+
+By default (`--output=quiet`) the terminal shows just two lines:
+
+```
+✓ Pyramid MoA done — 3 subtasks, cost 1240 tw-units (vs 18200 always-T3 → 93% saved).
+  Full report: ~/.copilot/session-state/<id>/files/pyramid-runs/<task>-<ts>.md
+```
+
+The full report — DAG, per-subtask answers, cost ledger, raw `pyramid-*`
+blocks — is **always** written to disk at the printed path. Open it on
+demand for the scientific detail. Use `--output=normal` to also see the
+final answer + ledger inline, or `--output=debug` to mirror v0.1.0's
+verbose output.
+
+### Cost units
+
+As of v0.2.0, all cost values (`--budget`, ledger totals, savings) are
+**token-weighted units**:
+
+```
+cost(call) = (input_tokens + output_tokens) * multiplier(model)
+```
+
+| Model              | Multiplier |
+|--------------------|------------|
+| claude-haiku-4.5   | 0.33       |
+| claude-sonnet-4.6  | 1.00       |
+| claude-opus-4.7    | 7.00       |
+
+GPT-track multipliers are placeholder — see
+`skills/pyramid-verify/SKILL.md`. Pre-0.2.0 the cost flag was documented as
+USD but always operated on flat ordinals (`1 / 5 / 25`). The new units are
+proportional to actual model spend, so the ratio Haiku:Sonnet:Opus is now
+`1 : 3 : 21` instead of the legacy `1 : 5 : 25`.
 
 ### Tier mapping
 

--- a/commands/pyramid.md
+++ b/commands/pyramid.md
@@ -8,7 +8,14 @@ description: Run a task through the Pyramid Mixture-of-Agents router — cheap t
 Usage:
 
 ```
-/pyramid <task description> [--track=claude|gpt|mixed] [--theta=0.75,0.85] [--max-tier=1|2|3] [--anchor=on|off] [--budget=<usd>] [--dry-run=on|off]
+/pyramid <task description> [--track=claude|gpt|mixed]
+                            [--theta=0.75,0.85]
+                            [--max-tier=1|2|3]
+                            [--anchor=on|off]
+                            [--budget=<tw-units>]
+                            [--dry-run=on|off]
+                            [--output=quiet|normal|debug]
+                            [--value-of-correctness=<float>]
 ```
 
 ## Flags
@@ -23,28 +30,43 @@ Usage:
 - `--anchor` — when escalating, whether to pass the rejected lower-tier answer
   to the higher tier as context. Default `off` (paper §4 warns of up to −18pp
   accuracy degradation from anchoring on incorrect reasoning).
-- `--budget` — optional USD cap on estimated spend. When the projected cost of
-  the next escalation would exceed remaining budget, accept the best-so-far
-  answer instead.
+- `--budget` — optional cost cap in **token-weighted units** (`tw-units`,
+  see `skills/pyramid-verify/SKILL.md` for the formula). When the projected
+  cost of the next escalation would exceed remaining budget, accept the
+  best-so-far answer instead. **Breaking change in 0.2.0**: the flag was
+  previously documented as USD but always operated on ordinal units; it now
+  uses token-weighted units explicitly.
 - `--dry-run` — when `on`, print the DAG and planned tiers but do not dispatch
   any work. Default `off`.
+- `--output` — terminal verbosity. Default `quiet`.
+  - `quiet` (default): a two-line summary + path to a per-run Markdown report
+    written under `~/.copilot/session-state/<id>/files/pyramid-runs/`.
+  - `normal`: quiet output plus the synthesized final answer plus the cost ledger.
+  - `debug`: everything in `normal` plus the DAG tree and every raw
+    `pyramid-result` / `pyramid-verdict` / `pyramid-decision` block. (This
+    was the v0.1.0 default; it is now opt-in.)
+  Regardless of level, the full report file is always written to disk.
+- `--value-of-correctness` — float multiplier in the VoC escalation rule.
+  Default `8` (re-tuned in 0.2.0 from the legacy `10` for the new
+  token-weighted cost ratios).
 
 ## What this command does
 
 When invoked, you (the host agent) MUST:
 
 1. Parse the user's task description and any flags above. Apply defaults for
-   anything not provided. Store the resolved configuration as `pyramid_config`
-   (track → tier-model map, theta, max_tier, anchor, budget, dry_run).
+   anything not provided. Resolve `session_dir` from the current Copilot CLI
+   session-state path. Store the resolved configuration as `pyramid_config`
+   (track → tier-model map, theta, max_tier, anchor, budget, dry_run,
+   output_level, value_of_correctness, session_dir).
 
 2. Invoke the **`pyramid-orchestrate`** skill, passing `pyramid_config` and the
    user's task description. That skill encodes the full Hansen-Zilberstein
-   anytime-monitoring control loop.
+   anytime-monitoring control loop and writes a JSON trace + Markdown report.
 
-3. After orchestration completes, present:
-   - The aggregated final answer / code edits.
-   - The **cost ledger** produced by `pyramid-aggregate`, showing per-subtask
-     tier reached, escalation reason, and estimated tokens / cost.
+3. After orchestration completes, the **`pyramid-aggregate`** skill prints the
+   summary at the configured `--output` level. Do NOT additionally print the
+   ledger or raw blocks yourself — they are already in the report file.
 
 Do **not** attempt to solve the task yourself — your role for this command is
 strictly to drive the pyramid skills.

--- a/docs/benchmarks/baseline-metrics.md
+++ b/docs/benchmarks/baseline-metrics.md
@@ -1,0 +1,75 @@
+# Pyramid MoA — baseline metrics
+
+This file is updated after every benchmark run. Each section captures one
+benchmark execution: config, methodology delta vs `tasks.md`, raw metrics,
+and a before/after comparison against the prior baseline.
+
+## How to read this file
+
+- Source of truth is the per-run JSON trace under
+  `~/.copilot/session-state/<id>/files/pyramid-runs/<task>-<ts>.json`.
+- Add a new section at the top for each new run; never overwrite
+  historical sections.
+- "Before" column = the previous published baseline; "After" = the run you
+  are reporting.
+
+---
+
+## Baseline #1 — methodology bring-up (token-weighted UX release, 0.2.0)
+
+**Status:** _placeholder — full 12 × 3 benchmark not yet executed_
+
+**Why a placeholder:** the v0.2.0 PR ships the instrumentation, cost
+model, and quiet-output UX needed to *measure* the benchmark, but a full
+12-task × 3-run execution against live LLMs was deferred to a follow-up.
+This section establishes the schema; numbers populate on the next run.
+
+**Config (planned):**
+
+```
+--track=claude --theta=0.75,0.85 --anchor=off
+--budget=50000 --output=quiet --value-of-correctness=8
+--max-tier=3
+```
+
+**Per-task table (to be filled):**
+
+| # | Task slug                          | Final tier | Verifier conf | Decision path | Tokens (in/out) | Cost (tw) | Pass? |
+|---|------------------------------------|------------|---------------|---------------|------------------|-----------|-------|
+| 1 | list-md-modified-7d                | —          | —             | —             | —                | —         | —     |
+| 2 | rename-pyramid-verify-folder       | —          | —             | —             | —                | —         | —     |
+| 3 | fix-broken-readme-links            | —          | —             | —             | —                | —         | —     |
+| 4 | add-retry-budget-flag              | —          | —             | —             | —                | —         | —     |
+| 5 | refactor-orchestrate-split-logging | —          | —             | —             | —                | —         | —     |
+| 6 | investigate-anchoring-degradation  | —          | —             | —             | —                | —         | —     |
+| 7 | design-plugin-sandbox              | —          | —             | —             | —                | —         | —     |
+| 8 | generate-skill-api-docs            | —          | —             | —             | —                | —         | —     |
+| 9 | verify-tools-frontmatter           | —          | —             | —             | —                | —         | —     |
+| 10| quantum-verifier-adversarial       | —          | —             | —             | —                | —         | —     |
+| 11| make-it-better-vague               | —          | —             | —             | —                | —         | —     |
+| 12| dry-run-task5                      | n/a        | n/a           | dry-run       | 0 / 0            | 0         | —     |
+
+**Aggregate metrics (to be filled):**
+
+| Metric                                     | Target  | Measured |
+|--------------------------------------------|---------|----------|
+| Mean savings vs always-tier-3 (#1–9)       | ≥ 35%   | —        |
+| Tier-1 accept-rate (#1–9)                  | ≥ 60%   | —        |
+| Tier-3 dispatch rate (#1–6, #8, #9)        | ≤ 15%   | —        |
+| Median terminal output lines (`quiet`)     | ≤ 5     | —        |
+| Median report file size                    | n/a     | —        |
+| Adversarial #10 hit max_tier and warned    | yes     | —        |
+| Adversarial #11 terminated within budget   | yes     | —        |
+| Dry-run #12 wrote trace, no dispatch       | yes     | —        |
+
+**Open follow-ups discovered during bring-up:**
+
+- Confirm GPT-track multipliers with the user before benchmarking the
+  `gpt` and `mixed` tracks (currently placeholder values in
+  `pyramid-verify`).
+- Investigate whether the `task` tool surfaces token counts directly. If
+  not, the `cost_estimated: true` path will be exercised and the savings
+  numbers should be marked accordingly.
+- Re-tune `value_of_correctness` empirically on the first real baseline.
+  The 0.2.0 default of `8` was derived from the 1:3:21 ratio change but
+  not yet validated against measured accept-rate / savings curves.

--- a/docs/benchmarks/tasks.md
+++ b/docs/benchmarks/tasks.md
@@ -1,0 +1,71 @@
+# Pyramid MoA — standard benchmark suite
+
+This file defines the canonical task suite used to measure Pyramid MoA's
+routing efficiency, escalation behavior, and developer-UX overhead. Re-run
+after non-trivial changes to any agent, skill, or command and update
+`baseline-metrics.md`.
+
+## Methodology
+
+For each task:
+
+1. Run with default config: `--track=claude --theta=0.75,0.85 --anchor=off
+   --budget=50000 --output=quiet --value-of-correctness=8`.
+2. Run a control with `--max-tier=1` to establish "always-tier-1" cost.
+3. Compute always-tier-3 reference analytically from the captured token
+   totals × Opus multiplier (7.00). No actual tier-3 dispatch needed.
+4. Repeat each run **3×** and report the median for each metric (LLM
+   nondeterminism).
+5. Tasks are read-only or hypothetical against this repo; **no real file
+   edits are applied** during benchmarking.
+
+All runs read the JSON trace under
+`<session>/files/pyramid-runs/` to derive the metrics in
+`baseline-metrics.md`. The trace is the single source of truth.
+
+## Task table
+
+| #  | Task                                                                  | Kind          | Expected difficulty | Stress target                                  |
+|----|-----------------------------------------------------------------------|---------------|---------------------|------------------------------------------------|
+| 1  | "List all Markdown files modified in last 7 days"                     | read          | low (0.10)          | tier-1 single-shot baseline                    |
+| 2  | "Rename the `pyramid-verify` skill folder to `pyramid-verifier-skill`"| transform     | low (0.20)          | tier-1, multi-file edit (hypothetical)         |
+| 3  | "Fix any markdown link that points at a non-existent path in README"  | transform     | medium (0.40)       | tier-1, expected accept                        |
+| 4  | "Add a `--retry-budget=N` flag to `/pyramid:pyramid`"                 | synthesize    | medium (0.55)       | tier-1, expected escalation to tier-2          |
+| 5  | "Refactor pyramid-orchestrate to split orchestration from logging"    | synthesize    | high (0.80)         | should skip tier-1 → tier-2/3                  |
+| 6  | "Investigate why anchoring=on degrades accuracy per the paper"        | synthesize    | high (0.70)         | debug-style path; ambiguity bumps              |
+| 7  | "Design a sandboxing model so untrusted plugins can't read this repo" | synthesize    | very high (0.90)    | exercises tier-3 path                          |
+| 8  | "Generate API-style docs for the four pyramid-* skills"               | write         | medium (0.40)       | tier-1, large output                           |
+| 9  | "Verify that every `tools` entry in agent frontmatter is a real tool" | verify        | medium (0.30)       | tier-1, exhaustive check                       |
+| 10 | "Implement a quantum-resistant verifier" (adversarial)                | synthesize    | trick (0.95)        | should hit `max_tier`                          |
+| 11 | "Make it better" (adversarial vague)                                  | synthesize    | trick (high+ambig)  | tests `pyramid-decompose` robustness           |
+| 12 | Task #5 with `--dry-run=on`                                           | dry-run       | n/a                 | path coverage for dry-run + trace write        |
+
+## Per-task acceptance gates
+
+| #  | Pass criteria                                                                                  |
+|----|------------------------------------------------------------------------------------------------|
+| 1  | Final tier ≤ 2; verifier confidence ≥ 0.80; ≤ 1 escalation.                                    |
+| 2  | Tier-1 accept; no escalations.                                                                 |
+| 3  | Tier-1 accept; no escalations.                                                                 |
+| 4  | At least one escalation triggered; final tier 2 or 3; final answer mentions a flag-parsing edit. |
+| 5  | Initial tier ≥ 2 (skip tier-1 path); final tier ≥ 2.                                           |
+| 6  | Final answer references "−18 pp" or paper §4; final tier ≤ 2.                                  |
+| 7  | Final tier = 3; non-empty answer; budget not exhausted.                                        |
+| 8  | Tier-1 accept; output ≥ 4 doc sections.                                                        |
+| 9  | Tier-1 accept; verifier evidence references at least one frontmatter file.                     |
+| 10 | Subtask reaches `max_tier`; orchestrator emits `⚠ max_tier without accept`.                    |
+| 11 | DAG has ≥ 2 nodes; no infinite loop; total cost ≤ budget.                                      |
+| 12 | Dry-run prints DAG; no solver/verifier dispatched; trace JSON written with `dry_run: true`.    |
+
+## Aggregate acceptance gates
+
+Across the non-adversarial subset (#1–#9):
+
+- **Mean savings vs always-tier-3 ≥ 35%** (paper claims up to 42.9%).
+- **Tier-1 accept-rate ≥ 60%**.
+- **Tier-3 dispatch rate ≤ 15%** (excluding tasks #7 and #10 which target it).
+- **Median terminal-output line count ≤ 5** at default `--output=quiet`
+  (UX gate; full report file preserves all detail).
+
+Adversarial tasks (#10, #11) are excluded from savings averages but must
+still terminate cleanly within `--budget=50000`.

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pyramid",
   "description": "Hierarchical Mixture-of-Agents router for Copilot CLI. Decomposes a task, dispatches subtasks to the cheapest viable tier, verifies output, and escalates only when a Hansen-Zilberstein Value-of-Computation rule says it's worth it. Based on arXiv:2602.19509.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": {
     "name": "pyramid-moa contributors"
   },

--- a/skills/pyramid-aggregate/SKILL.md
+++ b/skills/pyramid-aggregate/SKILL.md
@@ -1,76 +1,123 @@
 ---
 name: pyramid-aggregate
-description: Merge Pyramid MoA subtask results into a single user-facing response with a cost ledger showing tier escalations and estimated savings.
+description: Merge Pyramid MoA subtask results into a single user-facing response, write a per-run report file, and print a summary at the configured verbosity.
 ---
 
 # pyramid-aggregate
 
 Final step of the Pyramid MoA pipeline. Combines per-subtask results into a
-single coherent answer and prints the cost ledger so the user can see what
-the router did and what it saved.
+single coherent answer, **writes a Markdown per-run report** to disk, and
+prints a terminal summary at one of three verbosity levels.
 
 ## Inputs
 
 - `results`: map of subtask id → `pyramid-result` block
-- `ledger`: list of `{subtask_id, tier, verifier_confidence, decision, reason, estimated_cost_used}`
+- `ledger`: list of `{subtask_id, tier, verifier_confidence, decision, reason, cost_used}`
 - `dag`: original `pyramid-dag` block
 - `task`: original user task description
-- `spent_so_far`: total estimated cost (relative units)
+- `trace`: structured trace dict from `pyramid-orchestrate` (with `subtasks`,
+  `totals`, `config`, etc.)
+- `pyramid_config`: includes `output_level` (`quiet | normal | debug`,
+  default `quiet`) and `session_dir`
 
-## Step 1 — Compose the final answer
+## Step 1 — Always: write the per-run report file
 
-Walk `dag.nodes` in topological order. For each node, take the corresponding
-entry from `results` and:
+Render the full report as Markdown to:
 
-- **`read` / `verify`**: include the answer text as a brief bullet.
-- **`transform` / `write` / `synthesize`**: if the answer describes file edits
-  (paths + diffs), summarize them as a "Files changed" block. If it includes
-  free-text reasoning, condense to 1–3 sentences.
+```
+<session_dir>/files/pyramid-runs/<task-slug>-<YYYYMMDD-HHMMSS>.md
+```
 
-Produce a single final response with three sections:
+Using the same `task-slug-timestamp` stem as the JSON trace from
+`pyramid-orchestrate` so the two files pair up.
 
-1. **Result** — the synthesized answer to the user's original task.
-2. **Files changed** — bulleted list of files written/edited across all subtasks
-   (deduplicated). Skip if none.
-3. **Pyramid MoA ledger** — formatted as below.
+Report contents (in order):
 
-## Step 2 — Format the ledger
+1. **H1**: the original task.
+2. **Config**: track, theta, max_tier, anchor, budget, output_level,
+   value_of_correctness — as a fenced code block.
+3. **DAG**: render `dag.nodes` as an indented tree (parent → children),
+   not raw JSON. Show `id (kind, prior=X.XX)`.
+4. **Per-subtask sections**: for each node in topological order:
+   - Tier path (e.g., `T1 → T2 → accept`).
+   - Final verifier confidence and any `issues` from the last verdict.
+   - The full `answer` text (or a `…[truncated at 32 KB]` marker if larger).
+5. **Cost ledger** (the table from Step 2 below).
+6. **Savings summary** (from Step 3 below).
+7. **Appendix — raw blocks**: for debugging, dump each subtask's raw
+   `pyramid-result`, `pyramid-verdict`, and `pyramid-decision` blocks.
+
+The full report file is written **regardless of `output_level`** — it is
+the durable artifact users can open after the fact.
+
+## Step 2 — Format the cost ledger
 
 Render as a markdown table:
 
 ```
-| Subtask           | Final tier | Confidence | Decision path                  | Cost |
-|-------------------|------------|------------|--------------------------------|------|
-| <id (kind)>       | T1/T2/T3   | 0.XX       | T1→accept  /  T1→T2→accept     | X.X  |
-| ...               | ...        | ...        | ...                            | ...  |
-| **Total**         |            |            |                                | X.X  |
+| Subtask           | Final tier | Confidence | Decision path        | Tokens (in/out) | Cost (tw) |
+|-------------------|------------|------------|----------------------|-----------------|-----------|
+| <id (kind)>       | T1/T2/T3   | 0.XX       | T1→accept            | 1234 / 567      | 612.3     |
+| ...               | ...        | ...        | ...                  | ...             | ...       |
+| **Total**         |            |            |                      | I / O           | X.X       |
 ```
 
-The `Decision path` column reconstructs the escalation chain by walking the
-ledger entries for that subtask in order.
+`Cost (tw)` is in token-weighted units per `pyramid-verify`'s model.
+`Decision path` is reconstructed from `subtask.tier_path` plus the final
+accept/max-tier outcome.
 
-Below the table, print a one-line **savings summary**:
+## Step 3 — Compute the savings summary
 
 ```
-Pyramid MoA: total cost = X.X units; always-tier-3 cost would have been Y.Y units → saved (Y.Y − X.X) / Y.Y * 100 = Z%.
+always_tier3_cost = (totals.tokens_in_total + totals.tokens_out_total)
+                    * multiplier(track_models[3])
+savings_pct       = (always_tier3_cost - totals.cost_tw_units) / always_tier3_cost * 100
 ```
 
-Where `always-tier-3 cost = sum(cost_of_tier3_for_track) for each subtask`.
-Also note any subtasks that hit `max_tier` without reaching the threshold,
-prefixed with `⚠`.
+One-liner:
 
-## Step 3 — Sanity checks
+```
+Pyramid MoA: cost = X.X tw-units; always-tier-3 baseline = Y.Y → saved Z%.
+```
+
+Note any subtasks that hit `max_tier` without `accept`, prefixed with `⚠`.
+
+## Step 4 — Print the terminal summary at the right verbosity
+
+| `output_level` | Terminal output                                                                |
+|----------------|--------------------------------------------------------------------------------|
+| `quiet` (default) | Two lines: a tick + cost summary, plus a `Full report:` path.               |
+| `normal`       | Quiet output **plus** the synthesized final answer **plus** the cost-ledger table. |
+| `debug`        | Normal output **plus** the rendered DAG tree **plus** every raw `pyramid-*` block (today's behavior). |
+
+### `quiet` output template
+
+```
+✓ Pyramid MoA done — <N> subtasks, cost <X> tw-units (vs <Y> always-T3 → <Z>% saved).
+  Full report: <absolute path to .md report>
+```
+
+### Always-on warnings (any verbosity)
+
+Even at `quiet`, surface a one-line `⚠` warning above the summary for:
+
+- Any subtask that hit `max_tier` without `decision == "accept"`.
+- Any malformed solver output (handled per `pyramid-orchestrate` failure rules).
+- Any `cost_estimated: true` calls (so the user knows token counts were
+  approximated, not measured).
+
+## Step 5 — Sanity checks
 
 Before returning:
 
 - Every subtask in `dag.nodes` must appear in both `results` and the ledger.
-  If any are missing, add a `⚠ Subtask <id> did not complete` line to the
-  ledger and surface this prominently above the result.
-- If the response mentions file paths, verify each exists (`view` or `glob`)
-  and warn in the ledger if any do not.
+  Missing → `⚠ Subtask <id> did not complete` line above the summary.
+- If the response mentions file paths, `glob` them and warn in the report
+  file (and as a `⚠` line at quiet level) if any do not exist.
+- Cap the report file at 1 MB; truncate any individual `answer` field
+  beyond 32 KB with `…[truncated]`.
 
 ## Output
 
-Print the final response (Result + Files changed + Ledger) directly. Do not
-return a fenced block — this is the user-facing output, not data for another
-skill.
+Print only the summary appropriate to `output_level`. The full detail
+lives in the report file written in Step 1; users open it on demand.

--- a/skills/pyramid-orchestrate/SKILL.md
+++ b/skills/pyramid-orchestrate/SKILL.md
@@ -15,45 +15,122 @@ hands control here with a `pyramid_config` and the user's task description.
   - `theta`: `[θ₁, θ₂]` (default `[0.75, 0.85]`)
   - `max_tier`: `1 | 2 | 3` (default `3`)
   - `anchor`: `true | false` (default `false`)
-  - `budget`: USD cap or `null`
+  - `budget`: token-weighted-unit cap or `null` (was previously documented as USD; was always ordinal)
   - `dry_run`: `true | false` (default `false`)
+  - `output_level`: `quiet | normal | debug` (default `quiet`)
+  - `value_of_correctness`: float (default `8`, see `pyramid-verify`)
+  - `session_dir`: absolute path to the current session-state folder, used for trace + report files
 - `task`: free-text user task description.
 
 ## Algorithm
 
 ```
-ledger = []                          # per-subtask trace
-spent_so_far = 0.0
+ledger = []                          # per-subtask trace (rich)
+spent_so_far = 0.0                   # token-weighted units (tw-units)
 results = {}                          # subtask_id -> final pyramid-result
+trace = {                             # written to disk at the end
+    "task": task,
+    "config": pyramid_config,
+    "started_at": now_iso(),
+    "subtasks": [],                  # one entry per DAG node
+    "totals": {}                     # filled at end
+}
 
 dag = invoke skill pyramid-decompose with task         # returns pyramid-dag block
+trace["dag"] = dag
 order = topological_sort(dag.nodes)
 
 if pyramid_config.dry_run:
     print_dag_and_planned_tiers(dag, pyramid_config)
+    write_trace(trace, pyramid_config.session_dir, dry_run=True)
     return  # no dispatch, no aggregate
 
 for node in order:
-    tier = pick_initial_tier(node.difficulty_prior)    # see below
+    tier = pick_initial_tier(node.difficulty_prior)
     last_answer = null
     last_verdict = null
+    subtask_trace = {"id": node.id, "tier_path": [], "verdicts": [], "calls": []}
     while True:
         ctx = build_context(node, results, last_verdict, anchor, last_answer)
-        answer = dispatch(tier, node, ctx)              # task tool, model override
-        verdict = invoke pyramid-verify(node, tier, answer, pyramid_config + spent_so_far)
+        t0 = now_ms()
+        answer, call_meta = dispatch(tier, node, ctx)   # call_meta: input_tokens, output_tokens, model
+        latency = now_ms() - t0
+        subtask_trace["calls"].append({
+            "tier": tier, "model": call_meta.model,
+            "input_tokens": call_meta.input_tokens,
+            "output_tokens": call_meta.output_tokens,
+            "latency_ms": latency,
+            "cost_estimated": call_meta.cost_estimated,
+            "output_chars": len(answer.answer),
+            "output_lines": answer.answer.count("\n") + 1,
+        })
+        verdict = invoke pyramid-verify(node, tier, answer, call_meta, pyramid_config + spent_so_far)
         spent_so_far += verdict.estimated_cost_used
+        subtask_trace["tier_path"].append(tier)
+        subtask_trace["verdicts"].append(verdict)
 
-        ledger.append({node, tier, verdict.verifier_confidence, verdict.decision, verdict.reason})
+        ledger.append({"node": node, "tier": tier,
+                       "verifier_confidence": verdict.verifier_confidence,
+                       "decision": verdict.decision, "reason": verdict.reason,
+                       "cost_used": verdict.estimated_cost_used})
 
         if verdict.decision == "accept" or tier == pyramid_config.max_tier:
             results[node.id] = answer
+            subtask_trace["final_tier"] = tier
+            subtask_trace["accepted"] = (verdict.decision == "accept")
             break
         tier = verdict.next_tier
         last_answer = answer
         last_verdict = verdict
+    trace["subtasks"].append(subtask_trace)
 
-invoke pyramid-aggregate with (results, ledger, dag, task)
+trace["totals"] = compute_totals(trace, dag)            # see "Totals" below
+write_trace(trace, pyramid_config.session_dir)
+invoke pyramid-aggregate with (results, ledger, dag, task, trace, pyramid_config)
 ```
+
+### Capturing call metadata (`call_meta`)
+
+After each `task`-tool dispatch, capture:
+
+- `model`: the model id passed to the call.
+- `input_tokens`, `output_tokens`: read from the tool's response if surfaced.
+  If not surfaced, estimate as `len(prompt) / 4` and `len(answer_text) / 4`
+  respectively, and set `cost_estimated: true`.
+- `cost`: `(input_tokens + output_tokens) * multiplier(model)` (multipliers
+  defined in `pyramid-verify` SKILL).
+
+### Totals computed at the end
+
+```
+totals = {
+  "subtasks_total": <int>,
+  "subtasks_accepted": <int>,
+  "subtasks_max_tier_reached": <int>,
+  "tier_dispatches": {1: <int>, 2: <int>, 3: <int>},
+  "verifier_calls": <int>,
+  "tokens_in_total": <int>,
+  "tokens_out_total": <int>,
+  "cost_tw_units": <float>,
+  "cost_tw_units_always_tier3": <float>,   # sum(tokens) * multiplier(tier3 model)
+  "savings_pct": <float>,                   # 1 - cost / cost_always_tier3
+  "wall_clock_ms": <int>
+}
+```
+
+### Trace file location
+
+Write the trace as JSON to:
+
+```
+<session_dir>/files/pyramid-runs/<task-slug>-<YYYYMMDD-HHMMSS>.json
+```
+
+Where `task-slug` is the first 40 ASCII-safe chars of the task description,
+kebab-case. Create the `pyramid-runs/` directory if missing.
+
+If `session_dir` is not provided, fall back to
+`./.pyramid-runs/` in the current working directory.
 
 ### `pick_initial_tier(prior)`
 
@@ -161,9 +238,11 @@ After the loop completes, invoke the `pyramid-aggregate` skill with:
 - `ledger`: full per-subtask trace
 - `dag`: the original DAG
 - `task`: original user task
-- `spent_so_far`: total estimated cost
+- `trace`: the structured trace dict (post-`compute_totals`)
+- `pyramid_config`: includes `output_level`, `session_dir`
 
-The aggregate skill produces the user-facing response.
+The aggregate skill produces the user-facing response **and** writes the
+human-readable per-run report Markdown file alongside the JSON trace.
 
 ## Failure handling
 

--- a/skills/pyramid-verify/SKILL.md
+++ b/skills/pyramid-verify/SKILL.md
@@ -33,15 +33,36 @@ Parse the returned `pyramid-verdict` JSON. Fields: `confidence`, `issues`,
 
 ## Step 2 — Apply the escalation rule (Hansen-Zilberstein VoC)
 
-Per-model **cost table** (relative units, scaled per 1k tokens; treat as
-ordinal — only ratios matter):
+### Token-weighted cost model (v0.2.0)
 
-| Tier | Claude track       | Cost | GPT track       | Cost |
-|------|--------------------|------|------------------|------|
-| 1    | claude-haiku-4.5   | 1    | gpt-5-mini       | 1    |
-| 2    | claude-sonnet-4.6  | 5    | gpt-5.4          | 4    |
-| 3    | claude-opus-4.7    | 25   | gpt-5.3-codex    | 20   |
-| V    | claude-haiku-4.5   | 1    | gpt-5-mini       | 1    |
+Pyramid MoA accounts cost in **token-weighted units** (`tw-units`),
+not flat ordinals. For any model call:
+
+```
+cost(call) = (input_tokens + output_tokens) * multiplier(model)
+```
+
+Per-model multipliers (per token, normalized so `claude-sonnet-4.6 = 1.0`):
+
+| Tier | Claude track          | Multiplier | GPT track          | Multiplier  |
+|------|-----------------------|------------|--------------------|-------------|
+| 1    | `claude-haiku-4.5`    | 0.33       | `gpt-5-mini`       | 0.10 (TBD)  |
+| 2    | `claude-sonnet-4.6`   | 1.00       | `gpt-5.4`          | 1.00 (TBD)  |
+| 3    | `claude-opus-4.7`     | 7.00       | `gpt-5.3-codex`    | 5.00 (TBD)  |
+| V    | `claude-haiku-4.5`    | 0.33       | `gpt-5-mini`       | 0.10 (TBD)  |
+
+GPT-track multipliers are placeholders pending confirmation.
+
+When the underlying `task` tool surfaces actual token counts, use them.
+Otherwise fall back to a tokenizer estimate (`len(prompt + answer) / 4`)
+and mark `cost_estimated: true` in the trace.
+
+For the VoC pre-escalation comparison (where the next tier's call has
+**not happened yet**), use a synthetic prior of **1500 input + 800 output
+tokens** for the planned next-tier call, multiplied by that tier's
+multiplier.
+
+### VoC escalation rule
 
 **Expected accuracy gain** from escalating tier N → N+1, given current
 verifier confidence `c`:
@@ -58,10 +79,15 @@ Use these calibrated `P_correct(N+1 | N wrong)` priors from the paper
 1. `confidence < theta[N]` (theta defaults: θ₁=0.75, θ₂=0.85), **OR**
    `would_benefit_from_escalation == true` AND `confidence < theta[N] + 0.05`.
 2. `tier < max_tier`.
-3. `expected_gain(N→N+1, confidence) * value_of_correctness >= cost(N+1) / cost(N)`.
-   Use `value_of_correctness = 10` as the default (correctness is ~10× more
-   valuable than the relative compute cost of tier-1).
-4. `spent_so_far + estimated_cost(N+1) <= budget` (skip if no budget set).
+3. `expected_gain(N→N+1, confidence) * value_of_correctness >= cost_ratio(N+1, N)`,
+   where `cost_ratio(N+1, N) = projected_cost(N+1) / observed_cost(N)`
+   using token-weighted costs from above. Default `value_of_correctness = 8`
+   (re-tuned from `10` for the new 1:3:21 cost ratio; see
+   `docs/benchmarks/baseline-metrics.md`).
+4. `spent_so_far + projected_cost(N+1) <= budget` in tw-units (skip if no
+   budget set). Note: `--budget` values are now interpreted as tw-units, not
+   USD — the flag was previously documented as USD but always operated on
+   ordinal units; this clarifies it.
 
 Otherwise **accept** the current answer as best-so-far.
 
@@ -78,10 +104,24 @@ Return exactly this fenced block to the orchestrator:
   "decision": "accept" | "escalate",
   "next_tier": null | 2 | 3,
   "reason": "<one sentence: why this decision per VoC>",
-  "estimated_cost_used": <number>
+  "estimated_cost_used": <number>,
+  "cost_breakdown": {
+    "solver_input_tokens": <int>,
+    "solver_output_tokens": <int>,
+    "solver_multiplier": <float>,
+    "verifier_input_tokens": <int>,
+    "verifier_output_tokens": <int>,
+    "verifier_multiplier": <float>,
+    "cost_estimated": <bool>
+  }
 }
 ```
 ````
+
+`estimated_cost_used` is in **token-weighted units** (tw-units) and equals
+`solver_call_cost + verifier_call_cost` for this verification step.
+`cost_breakdown` lets the orchestrator and `pyramid-aggregate` reconstruct
+totals and compute the always-tier-3 baseline by re-weighting tokens.
 
 The orchestrator uses `decision` to either move on to the next DAG node
 (accept) or re-dispatch the same subtask to `next_tier` (escalate).


### PR DESCRIPTION
## Summary

Two related changes shipped together as v0.2.0:

1. **Token-weighted cost accounting** replaces the legacy ordinal cost
   table. All ledger totals, `--budget` values, and the VoC escalation
   ratio are now in token-weighted units (`tw-units`):

       cost(call) = (input_tokens + output_tokens) × multiplier(model)

   With multipliers Haiku 0.33, Sonnet 1.00, Opus 7.00, the new
   Haiku:Sonnet:Opus ratio is **1 : 3 : 21** (was 1 : 5 : 25). Default
   `value_of_correctness` re-tuned **10 → 8** to compensate.

2. **Quiet-by-default UX.** Default terminal output drops from hundreds of
   lines (DAG JSON, every `pyramid-result`/`pyramid-verdict` block, full
   ledger) to two lines plus a path to a per-run Markdown report on disk.
   The full scientific detail is preserved in
   `~/.copilot/session-state/<id>/files/pyramid-runs/<task>-<ts>.md` and
   in a paired JSON trace.

Plus a benchmark suite (`docs/benchmarks/tasks.md`) and acceptance gates
that future runs report against (`docs/benchmarks/baseline-metrics.md`).

## Breaking changes (0.1.0 → 0.2.0)

- **Cost units** are now token-weighted, not ordinal `1/5/25`.
- **`--budget`** is now explicitly in tw-units (was always ordinal,
  was misleadingly documented as USD).
- **Default `--output`** is `quiet` (was effectively `debug`). Restore
  the old behavior with `--output=debug`.
- **`pyramid-decision`** schema gains a required `cost_breakdown` field.
  Other fields unchanged.

See `CHANGELOG.md` for the full list.

## What's in the PR

| Commit | Scope |
|--------|-------|
| `Add token-weighted cost model and per-run JSON trace` | `skills/pyramid-orchestrate/SKILL.md`, `skills/pyramid-verify/SKILL.md` |
| `Quiet by default: --output flag, two-line summary, per-run report file` | `skills/pyramid-aggregate/SKILL.md`, `commands/pyramid.md` |
| `Bump to 0.2.0 and add AGENTS.md, CHANGELOG.md, README updates` | `plugin.json`, `README.md`, `AGENTS.md`, `CHANGELOG.md` |
| `Add benchmark suite (tasks.md) and baseline-metrics scaffold` | `docs/benchmarks/tasks.md`, `docs/benchmarks/baseline-metrics.md` |

## Open follow-ups (called out in `baseline-metrics.md`)

- **GPT-track multipliers** are placeholder — `gpt-5-mini` 0.10,
  `gpt-5.4` 1.00, `gpt-5.3-codex` 5.00 — pending confirmation.
- The per-call **token-count surfacing** path through the underlying
  `task` tool needs validation; if not surfaced, the
  `cost_estimated: true` fallback path applies and is already reflected
  in the trace + UX warnings.
- `value_of_correctness=8` is a derived-not-measured default. The first
  live benchmark run should sweep `{6, 8, 10, 12}` and pin the value
  that maximizes savings without dropping tier-1 accept-rate < 60%.
- The full **12 × 3 benchmark execution** is intentionally deferred from
  this PR (it requires real LLM spend); the suite, gates, and metric
  schema are in place so the run is one command away.

## Test plan

- `python -c "import json, pathlib; json.load(open('plugin.json'))"` — ✅ valid.
- `git grep` for stale `USD` / ordinal references — only intentional
  migration notes in `CHANGELOG.md`, `README.md`, and the SKILL files
  remain.
- Frontmatter on every modified `.agent.md` / `SKILL.md` is unchanged in
  shape; only bodies were edited.
- Dry-run path (`--dry-run=on`) documentation preserved in
  `pyramid-orchestrate`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
