### PR TITLE
v0.2.1 — fix smoke-benchmark defects (B1–B4, C3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 All notable changes to this plugin are documented here.
 
+## 0.2.1 — smoke-benchmark fixes (B1–B4, C3)
+
+### Fixed
+
+- **B1 — Cost arithmetic.** `pyramid-orchestrate` now pins
+  `compute_totals` as the single source of truth for cost numbers, with
+  an explicit Python-style formula and a sanity assertion that
+  `totals.cost_tw_units` matches the per-call recomputation. Per-verdict
+  `estimated_cost_used` scalars are documented as informational only —
+  never substituted into totals. Smoke run had reported
+  `cost_tw_units = 0.5` for a task whose true value was ≈ 478.5.
+- **B2 — JSON trace must be written.** `pyramid-aggregate` now verifies
+  the JSON trace exists as Step 1 (pre-condition) and writes it itself
+  with a `⚠` warning if `pyramid-orchestrate` failed to. The orchestrate
+  skill now also explicitly contracts that `write_trace` runs before
+  invoking aggregate.
+- **B3 — Verifier short-circuit.** `pyramid-orchestrate` now contracts
+  that every dispatched answer must go through `pyramid-verify`. No
+  "verifier round-trip would cost more than the work" shortcut. Any
+  fast-path must live inside `pyramid-verify` itself with a named
+  heuristic and a `verifier_skipped: true` trace flag.
+- **B4 — Inline-resolved subtasks.** `pyramid-orchestrate` now contracts
+  that every DAG node must be dispatched. No "resolve inline" shortcut.
+- **C3 — Quiet is now actually quiet.** `pyramid-aggregate` Step 4 adds
+  a hard contract: at `output_level=quiet`, the terminal output is
+  exactly `⚠` warning lines plus the two-line summary. The host agent
+  must NOT append the synthesized answer body, headers, or tables.
+
+### Notes
+
+- No behavior changes for `--output=normal` or `--output=debug`.
+- No trace-shape changes; this release is backward-compatible with
+  v0.2.0 trace consumers.
+- Discovered via the v0.2.0 smoke benchmark (3 tasks). See
+  `docs/benchmarks/baseline-metrics.md` § Baseline #1 for raw evidence.
+
 ## 0.2.0 — token-weighted costs and quiet UX
 
 ### Breaking

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pyramid",
   "description": "Hierarchical Mixture-of-Agents router for Copilot CLI. Decomposes a task, dispatches subtasks to the cheapest viable tier, verifies output, and escalates only when a Hansen-Zilberstein Value-of-Computation rule says it's worth it. Based on arXiv:2602.19509.",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": {
     "name": "pyramid-moa contributors"
   },

--- a/skills/pyramid-aggregate/SKILL.md
+++ b/skills/pyramid-aggregate/SKILL.md
@@ -22,6 +22,15 @@ prints a terminal summary at one of three verbosity levels.
 
 ## Step 1 — Always: write the per-run report file
 
+**Pre-condition (B2 fix, v0.2.1):** the JSON trace was written by
+`pyramid-orchestrate` *before* this skill was invoked. Verify that
+`<session_dir>/files/pyramid-runs/<task-slug>-<YYYYMMDD-HHMMSS>.json`
+exists. If it does not, write it now from `trace` before doing anything
+else, and append a `⚠ JSON trace was written late by pyramid-aggregate`
+warning to the always-on warnings list. Do not proceed past this step
+until both the JSON trace and (later in this step) the Markdown report
+are on disk.
+
 Render the full report as Markdown to:
 
 ```
@@ -86,9 +95,22 @@ Note any subtasks that hit `max_tier` without `accept`, prefixed with `⚠`.
 
 | `output_level` | Terminal output                                                                |
 |----------------|--------------------------------------------------------------------------------|
-| `quiet` (default) | Two lines: a tick + cost summary, plus a `Full report:` path.               |
+| `quiet` (default) | Two lines: a tick + cost summary, plus a `Full report:` path. **No answer body, no DAG, no tables.** (C3 fix, v0.2.1.) |
 | `normal`       | Quiet output **plus** the synthesized final answer **plus** the cost-ledger table. |
 | `debug`        | Normal output **plus** the rendered DAG tree **plus** every raw `pyramid-*` block (today's behavior). |
+
+### Hard contract — quiet means quiet (added in v0.2.1, fixes C3)
+
+When `output_level == "quiet"`, the terminal output **must** be exactly:
+
+1. Zero or more `⚠` warning lines (one per warning).
+2. The two-line `quiet` template below.
+
+The host agent must NOT also append the synthesized answer body,
+markdown headers, bullet lists, tables, or any other commentary at
+quiet level. The full answer is in the report file written in Step 1
+— that is the user's escape hatch. If the user wants the answer inline,
+they pass `--output=normal`.
 
 ### `quiet` output template
 

--- a/skills/pyramid-orchestrate/SKILL.md
+++ b/skills/pyramid-orchestrate/SKILL.md
@@ -85,9 +85,36 @@ for node in order:
     trace["subtasks"].append(subtask_trace)
 
 trace["totals"] = compute_totals(trace, dag)            # see "Totals" below
-write_trace(trace, pyramid_config.session_dir)
-invoke pyramid-aggregate with (results, ledger, dag, task, trace, pyramid_config)
+trace_path = write_trace(trace, pyramid_config.session_dir)   # MUST succeed
+invoke pyramid-aggregate with (results, ledger, dag, task, trace, trace_path, pyramid_config)
 ```
+
+### Hard contract — no shortcuts (added in v0.2.1, fixes B1–B4)
+
+These rules are non-negotiable. The host agent may NOT optimize them away
+even on tasks it judges "trivial". Smoke benchmark of v0.2.0 found every
+one of these contracts broken at least once.
+
+1. **Every DAG node must be dispatched** to `dispatch(tier, node, ctx)`.
+   No "resolve inline" shortcut. If a node looks trivial, dispatch it to
+   tier 1 anyway — the cost is bounded and the verifier needs a real
+   answer to grade. (Defect B4.)
+2. **Every dispatched answer must go through `pyramid-verify`.** No
+   "verifier round-trip would cost more than the work" shortcut. The
+   verifier *is* the safety net; skipping it converts a router into a
+   single-tier wrapper. (Defect B3.) If a fast-path is ever justified
+   it must be added to `pyramid-verify` itself with a named heuristic
+   and a `verifier_skipped: true` trace flag — never decided by the
+   orchestrator.
+3. **`totals.cost_tw_units` is computed from `subtasks[*].calls[*]`,
+   never copied from a per-verdict scalar.** The exact formula is
+   pinned in "Totals" below. `verdict.estimated_cost_used` is
+   informational only — useful in the per-verdict ledger row, but
+   *never* substituted into the totals. (Defect B1.)
+4. **`write_trace` runs before `pyramid-aggregate`.** If the JSON write
+   fails, raise; do not invoke aggregate. The aggregate skill itself
+   re-checks that the JSON file exists before printing the quiet
+   summary. (Defect B2.)
 
 ### Capturing call metadata (`call_meta`)
 
@@ -102,21 +129,38 @@ After each `task`-tool dispatch, capture:
 
 ### Totals computed at the end
 
+`compute_totals(trace, dag)` is the **single source of truth** for cost
+numbers. It must always recompute from `subtasks[*].calls[*]`; never
+read or sum any per-verdict `estimated_cost_used` field.
+
+```python
+def compute_totals(trace, dag, multiplier):
+    calls = [c for st in trace["subtasks"] for c in st["calls"]]
+    tokens_in  = sum(c["input_tokens"]  for c in calls)
+    tokens_out = sum(c["output_tokens"] for c in calls)
+    cost_tw    = sum((c["input_tokens"] + c["output_tokens"])
+                     * multiplier(c["model"]) for c in calls)
+    cost_t3    = (tokens_in + tokens_out) * multiplier(track_models[3])
+    return {
+      "subtasks_total":             len(trace["subtasks"]),
+      "subtasks_accepted":          sum(1 for st in trace["subtasks"] if st["accepted"]),
+      "subtasks_max_tier_reached":  sum(1 for st in trace["subtasks"]
+                                        if st["final_tier"] == max_tier and not st["accepted"]),
+      "tier_dispatches":            {t: sum(1 for c in calls if c["tier"] == t) for t in (1,2,3)},
+      "verifier_calls":             sum(len(st["verdicts"]) for st in trace["subtasks"]),
+      "tokens_in_total":            tokens_in,
+      "tokens_out_total":           tokens_out,
+      "cost_tw_units":              round(cost_tw, 2),
+      "cost_tw_units_always_tier3": round(cost_t3, 2),
+      "savings_pct":                round(100 * (1 - cost_tw / cost_t3), 2) if cost_t3 else 0,
+      "wall_clock_ms":              sum(c.get("latency_ms") or 0 for c in calls),
+      "cost_estimated":             any(c.get("cost_estimated") for c in calls),
+    }
 ```
-totals = {
-  "subtasks_total": <int>,
-  "subtasks_accepted": <int>,
-  "subtasks_max_tier_reached": <int>,
-  "tier_dispatches": {1: <int>, 2: <int>, 3: <int>},
-  "verifier_calls": <int>,
-  "tokens_in_total": <int>,
-  "tokens_out_total": <int>,
-  "cost_tw_units": <float>,
-  "cost_tw_units_always_tier3": <float>,   # sum(tokens) * multiplier(tier3 model)
-  "savings_pct": <float>,                   # 1 - cost / cost_always_tier3
-  "wall_clock_ms": <int>
-}
-```
+
+**Sanity assertion before writing the trace:**
+`abs(totals.cost_tw_units - sum((c.in+c.out)*mult(c.model) for c in all_calls)) < 0.01`.
+If this fails, the totals are wrong — fix the formula, do not paper over.
 
 ### Trace file location
 


### PR DESCRIPTION
Fixes the four defects (B1–B4) and one calibration miss (C3) discovered by the v0.2.0 smoke benchmark in PR #2. Bumps version to 0.2.1 so `/plugin update` works.

## Defects fixed

| # | Defect | File | Fix |
|---|--------|------|-----|
| B1 | `cost_tw_units` was 0.5 (per-verdict scalar) instead of ~478 (recomputed from token counts) | `skills/pyramid-orchestrate/SKILL.md` | Pin `compute_totals` as the single source of truth with explicit Python-style formula and a sanity assertion. Document `estimated_cost_used` as informational only. |
| B2 | JSON trace not written for task #4 | `skills/pyramid-orchestrate/SKILL.md` + `skills/pyramid-aggregate/SKILL.md` | Orchestrate contracts `write_trace` runs before invoking aggregate. Aggregate verifies the JSON exists as Step 1 and writes it (with ⚠ warning) if missing. |
| B3 | Orchestrator emitted its own `pyramid-decision` block on task #1, skipping the verifier | `skills/pyramid-orchestrate/SKILL.md` | Contract: every dispatched answer must go through `pyramid-verify`. No orchestrator-emitted decision blocks. |
| B4 | Task #3 had a 3-node DAG; only 1 node was dispatched (others resolved inline) | `skills/pyramid-orchestrate/SKILL.md` | Contract: every DAG node must call `dispatch(tier, node, ctx)`; no resolve-inline shortcut. |
| C3 | At `--output=quiet` the answer body was still dumped to terminal | `skills/pyramid-aggregate/SKILL.md` | Step 4 hard contract: at quiet, terminal output is exactly ⚠ warnings + 2-line summary. |

## Verification

This is a declarative-skill change — no automated tests exist. Manual verification: after merge, run `/plugin update` then re-run the 3 smoke tasks from `docs/benchmarks/tasks.md`. Expected: B1–B4 do not recur and quiet mode is silent except for the 2-liner.

## Out of scope (still open)

- GPT-track multipliers — needs user input.
- Full 12 × 3 benchmark execution — needs a re-run after this lands.