### PR TITLE
Fix B5: cost-collapse on host-context calls (v0.2.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to this plugin are documented here.
 
+## 0.2.2 — fix B5 (cost-collapse on host-context calls)
+
+### Fixed
+
+- **B5 (#5)** — When a subtask's LLM call did not surface token counts
+  (the `task` tool's typical case), the orchestrator's fallback estimator
+  computed `len(prompt or "") / 4`. If the host completed work in its own
+  context the prompt and answer text were both empty strings, collapsing
+  the call's tokens — and therefore `cost_tw_units` and
+  `cost_tw_units_always_tier3` — to `0.0`. The quiet summary then printed
+  `cost 0.0 tw-units (vs 0.0 always-T3 → 0% saved)`, which is
+  mathematically defensible but actively misleading. (Surfaced in
+  Baseline #2, task #8.)
+
+  Two changes:
+
+  1. `skills/pyramid-orchestrate/SKILL.md` § "Capturing call metadata"
+     pins a per-call floor: `MIN_TOKENS_PER_CALL = 50`, applied to both
+     `input_tokens` and `output_tokens` in the unmeasured-tokens fallback.
+     A genuinely no-dispatch subtask must produce `subtask.calls = []`,
+     not a synthetic zero-token call.
+  2. `compute_totals` now returns `savings_pct = None` (instead of `0`)
+     when `cost_tw_units_always_tier3 == 0`. The aggregate skill's quiet
+     template substitutes a `cost not measurable (host context)` clause
+     and prepends a `⚠` warning rather than printing the misleading
+     `0% saved`.
+
+### Notes
+
+- No trace-shape changes beyond `savings_pct` being nullable. Existing
+  trace consumers should treat `None`/`null` as "undefined", not zero.
+- B6 (issue #6, orchestrator-bypass) and the residual C3 leak (issue #7)
+  are out of scope for this release.
+
 ## 0.2.1 — smoke-benchmark fixes (B1–B4, C3)
 
 ### Fixed

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pyramid",
   "description": "Hierarchical Mixture-of-Agents router for Copilot CLI. Decomposes a task, dispatches subtasks to the cheapest viable tier, verifies output, and escalates only when a Hansen-Zilberstein Value-of-Computation rule says it's worth it. Based on arXiv:2602.19509.",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": {
     "name": "pyramid-moa contributors"
   },

--- a/skills/pyramid-aggregate/SKILL.md
+++ b/skills/pyramid-aggregate/SKILL.md
@@ -119,6 +119,23 @@ they pass `--output=normal`.
   Full report: <absolute path to .md report>
 ```
 
+When `totals.savings_pct is None` (B5 fix, v0.2.2 — happens when
+`cost_tw_units_always_tier3 == 0`, i.e. no LLM calls were measurable),
+substitute the savings clause with `cost not measurable (host context)`
+and prepend a `⚠ Cost not measurable` warning. Concrete template in that
+edge case:
+
+```
+⚠ Cost not measurable — work completed in host context (no task-tool dispatch).
+✓ Pyramid MoA done — <N> subtasks, cost not measurable (host context).
+  Full report: <absolute path to .md report>
+```
+
+Never print `0% saved` or `0.0 tw-units (vs 0.0 always-T3)`. Both are
+mathematically defensible but actively misleading: a casual reader sees
+"0% saved" and concludes the plugin did nothing of value, when in
+reality the cost simply wasn't measurable.
+
 ### Always-on warnings (any verbosity)
 
 Even at `quiet`, surface a one-line `⚠` warning above the summary for:

--- a/skills/pyramid-orchestrate/SKILL.md
+++ b/skills/pyramid-orchestrate/SKILL.md
@@ -122,10 +122,22 @@ After each `task`-tool dispatch, capture:
 
 - `model`: the model id passed to the call.
 - `input_tokens`, `output_tokens`: read from the tool's response if surfaced.
-  If not surfaced, estimate as `len(prompt) / 4` and `len(answer_text) / 4`
-  respectively, and set `cost_estimated: true`.
+  If not surfaced, estimate as follows (B5 fix, v0.2.2):
+    - `input_tokens  = max(MIN_TOKENS_PER_CALL, ceil(len(prompt)        / 4))`
+    - `output_tokens = max(MIN_TOKENS_PER_CALL, ceil(len(answer_text)   / 4))`
+  where `MIN_TOKENS_PER_CALL = 50`. This floor prevents a host-context
+  call (where `prompt`/`answer_text` are unavailable and default to "")
+  from collapsing tokens — and therefore `cost_tw_units` — to **zero**,
+  which silently disables the savings calculation. Set
+  `cost_estimated: true` whenever this fallback fires.
 - `cost`: `(input_tokens + output_tokens) * multiplier(model)` (multipliers
   defined in `pyramid-verify` SKILL).
+
+If a call genuinely has no LLM dispatch (e.g. a pure inline computation
+the orchestrator does itself), do NOT append a `call` entry — leave
+`subtask.calls = []`. The B5 floor is for *attempted* dispatches whose
+token counts could not be measured, not for things that were never
+dispatched.
 
 ### Totals computed at the end
 
@@ -134,6 +146,8 @@ numbers. It must always recompute from `subtasks[*].calls[*]`; never
 read or sum any per-verdict `estimated_cost_used` field.
 
 ```python
+MIN_TOKENS_PER_CALL = 50  # B5 floor — see "Capturing call metadata"
+
 def compute_totals(trace, dag, multiplier):
     calls = [c for st in trace["subtasks"] for c in st["calls"]]
     tokens_in  = sum(c["input_tokens"]  for c in calls)
@@ -141,6 +155,13 @@ def compute_totals(trace, dag, multiplier):
     cost_tw    = sum((c["input_tokens"] + c["output_tokens"])
                      * multiplier(c["model"]) for c in calls)
     cost_t3    = (tokens_in + tokens_out) * multiplier(track_models[3])
+    # B5: if cost_t3 is 0 (no calls, or all calls had zero tokens despite
+    # the floor — should not happen in practice), savings_pct is undefined.
+    # Surface that explicitly with `null`, never paper over with 0.
+    if cost_t3 > 0:
+        savings_pct = round(100 * (1 - cost_tw / cost_t3), 2)
+    else:
+        savings_pct = None
     return {
       "subtasks_total":             len(trace["subtasks"]),
       "subtasks_accepted":          sum(1 for st in trace["subtasks"] if st["accepted"]),
@@ -152,7 +173,7 @@ def compute_totals(trace, dag, multiplier):
       "tokens_out_total":           tokens_out,
       "cost_tw_units":              round(cost_tw, 2),
       "cost_tw_units_always_tier3": round(cost_t3, 2),
-      "savings_pct":                round(100 * (1 - cost_tw / cost_t3), 2) if cost_t3 else 0,
+      "savings_pct":                savings_pct,                # None when cost_t3 == 0
       "wall_clock_ms":              sum(c.get("latency_ms") or 0 for c in calls),
       "cost_estimated":             any(c.get("cost_estimated") for c in calls),
     }


### PR DESCRIPTION
# Fix B5: cost-collapse on host-context calls (v0.2.2)

Closes #5.

## Problem

When the host CLI satisfied a subtask using its own context (no
sub-agent dispatch), `pyramid-orchestrate` recorded `input_tokens = 0`
and `output_tokens = 0`. The token-weighted formula then produced
`cost_tw_units = 0` **and** `cost_tw_units_always_tier3 = 0`, which made
`savings_pct` collapse to `0%` — the user saw a misleading
`cost 0.0 tw-units (vs 0.0 → 0% saved)` summary even when real work was
done. Documented as defect B5 in `docs/benchmarks/baseline-metrics.md`.

## Fix (two-pronged, both defensive)

1. **Token floor in the orchestrator's call-metadata fallback**
   (`skills/pyramid-orchestrate/SKILL.md`). When the underlying `task`
   tool does not surface token counts, we already fall back to
   `len(prompt + answer) / 4`. We now apply
   `MIN_TOKENS_PER_CALL = 50` so any *actually-dispatched* call has a
   nonzero cost. Genuine no-dispatch (host-context resolution) must
   produce `subtask.calls = []` so the savings math knows to substitute
   a "not measurable" message.

2. **Honest `None` for unmeasurable savings**
   (`skills/pyramid-orchestrate/SKILL.md` — `compute_totals`). When
   `cost_t3 == 0` (no metered tier-3 reference), `savings_pct = None`
   instead of `0`. Trace consumers must treat `null` as "undefined",
   not zero.

3. **Aggregate quiet-template substitution**
   (`skills/pyramid-aggregate/SKILL.md`). When `savings_pct is None`,
   the quiet summary now prints `cost not measurable (host context)`
   plus a `⚠ Cost not measurable…` warning line, instead of `0% saved`.

## Verification

Side-loaded the modified skills into the installed plugin path and
re-ran two benchmark tasks against `v0.2.2`:

| Task | Result | Cost (tw) | Savings | Notes |
|------|--------|-----------|---------|-------|
| #1 — list MD files modified last 7 days | ✓ pass | 255.75 | 95.29% | regression: matches Baseline #2 within nondeterminism (217.8 → 255.75; premium reqs 7.5 → 3) |
| #8 — generate API docs for 4 skills | ✓ pass | 4521.0 | 95.29% | did not trigger host-context path on this run; output normal |

Neither run regressed against Baseline #2 numbers. Neither naturally
exercised the host-context code path on this attempt (B6 is
out-of-scope and is the reason the path is rare), so the fix is
verified by code walkthrough + regression evidence rather than a
positive canary.

## Out of scope

- B6 (orchestrator skipping dispatch entirely) — tracked in #6.
- C3-residual (cost-attribution drift on retried subtasks) — tracked in #7.
- Adversarial-task safety — tracked in #8.

## Contract change

`pyramid-decision.savings_pct` (and the trace's `totals.savings_pct`)
is now nullable. Existing consumers that treated it as a number must
handle `null`. No version bump beyond 0.2.2 because the field's
*presence* is unchanged; only its domain widens to include `null`.
