### PR TITLE
Fix C3-residual: enforce quiet contract at command level (v0.2.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to this plugin are documented here.
 
+## 0.2.3 — Fix C3-residual quiet-mode leakage (#7)
+
+### Fixed
+
+- **C3 residual (#7)** — While v0.2.1 introduced the hard quiet contract,
+  ~3 of 7 baseline tasks still leaked answer-body text, headings, lists, or
+  tables to the terminal at `--output=quiet`. Root cause: the quiet
+  contract was described in `pyramid-aggregate` but not enforced as a
+  command-level post-condition, and the host agent assumed the contract was
+  advisory rather than mandatory.
+
+  Three changes:
+
+  1. `commands/pyramid.md` now includes a new "Post-conditions (hard
+     contract)" section at the end, restating the quiet rule in imperative
+     voice ("MUST", "MUST NOT") and cross-referencing the aggregate skill.
+  2. `skills/pyramid-aggregate/SKILL.md` — Updated both the quiet and
+     edge-case output templates to add a third line: `(Answer body
+     suppressed — pass --output=normal to see it here.)`. Added a new
+     "Quiet contract violation detection" subsection instructing the host
+     to prepend a `⚠ Quiet contract violated by host…` warning if it has
+     already leaked any body content in the same turn (self-attestation).
+  3. `plugin.json` version bumped to 0.2.3.
+
+### Notes
+
+- The quiet contract is now treated as a hard safety property, not a hint.
+- This release is backward-compatible with v0.2.x trace consumers; no
+  schema changes beyond cosmetic output.
+- The "violated by host" warning is retroactive (it does not prevent the
+  leak, only discloses it) to avoid host-side buffering complexity.
+
 ## 0.2.2 — fix B5 (cost-collapse on host-context calls)
 
 ### Fixed

--- a/commands/pyramid.md
+++ b/commands/pyramid.md
@@ -70,3 +70,16 @@ When invoked, you (the host agent) MUST:
 
 Do **not** attempt to solve the task yourself — your role for this command is
 strictly to drive the pyramid skills.
+
+## Post-conditions (hard contract)
+
+When `--output=quiet` (the default), the terminal output **MUST** be:
+
+1. Zero or more `⚠` warning lines (one per warning).
+2. Exactly two lines: the cost summary and the full report path.
+
+You **MUST NOT** also print the synthesized answer body, markdown headers, bullet lists, tables, code blocks, or any other commentary at quiet level.
+
+The full answer is in the per-run Markdown report written by `pyramid-aggregate` in Step 1 — that is the user's escape hatch. If the user wants the answer inline, they MUST pass `--output=normal`.
+
+See `skills/pyramid-aggregate/SKILL.md` § "Hard contract — quiet means quiet" for details.

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pyramid",
   "description": "Hierarchical Mixture-of-Agents router for Copilot CLI. Decomposes a task, dispatches subtasks to the cheapest viable tier, verifies output, and escalates only when a Hansen-Zilberstein Value-of-Computation rule says it's worth it. Based on arXiv:2602.19509.",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "author": {
     "name": "pyramid-moa contributors"
   },

--- a/skills/pyramid-aggregate/SKILL.md
+++ b/skills/pyramid-aggregate/SKILL.md
@@ -117,6 +117,7 @@ they pass `--output=normal`.
 ```
 ✓ Pyramid MoA done — <N> subtasks, cost <X> tw-units (vs <Y> always-T3 → <Z>% saved).
   Full report: <absolute path to .md report>
+  (Answer body suppressed — pass --output=normal to see it here.)
 ```
 
 When `totals.savings_pct is None` (B5 fix, v0.2.2 — happens when
@@ -129,12 +130,27 @@ edge case:
 ⚠ Cost not measurable — work completed in host context (no task-tool dispatch).
 ✓ Pyramid MoA done — <N> subtasks, cost not measurable (host context).
   Full report: <absolute path to .md report>
+  (Answer body suppressed — pass --output=normal to see it here.)
 ```
 
 Never print `0% saved` or `0.0 tw-units (vs 0.0 always-T3)`. Both are
 mathematically defensible but actively misleading: a casual reader sees
 "0% saved" and concludes the plugin did nothing of value, when in
 reality the cost simply wasn't measurable.
+
+### Quiet contract violation detection (C3 fix, v0.2.3)
+
+Before printing the quiet summary, **check with self-attestation**: if you
+(the host) have already emitted any answer body, markdown headings, bullet
+lists, code blocks, or other commentary in this same turn, prepend this
+warning before the summary:
+
+```
+⚠ Quiet contract violated by host — answer body leaked above. The 2-line summary below is canonical; everything above the warning is non-canonical leakage.
+```
+
+This catches host-side violations of the contract. Do not filter or suppress
+the leaked content; the violation warning is a retroactive disclosure.
 
 ### Always-on warnings (any verbosity)
 


### PR DESCRIPTION
# Fix C3-residual: enforce quiet contract at command level (#7)

Closes #7.

## Problem

Baseline #2 (v0.2.1) found that the `--output=quiet` hard contract in
`skills/pyramid-aggregate/SKILL.md` was treated as advisory by the host
agent on ~3 of 7 tasks (notably tasks #5 and #6, where the user prompt
strongly invited a direct prose answer). The host appended a long
Markdown answer body before the 2-line summary, defeating the quiet UX.

## Fix (all three suggestions from issue #7)

1. **`commands/pyramid.md` — new `## Post-conditions (hard contract)`
   section** at the end of the slash command spec. Restates the quiet
   rule in imperative `MUST` / `MUST NOT` voice as a *command-level*
   post-condition. Command-level rules are honored more strictly by
   the host than skill-internal rules.

2. **`skills/pyramid-aggregate/SKILL.md` — quiet template gains a third
   line:** `(Answer body suppressed — pass --output=normal to see it
   here.)`. Same line added to the B5 host-context edge-case template.
   Acts as a constant in-output reminder so the user always sees the
   escape hatch.

3. **Host self-attestation violation warning.** New "Quiet contract
   violation detection (C3 fix, v0.2.3)" subsection in aggregate Step 4
   instructs the host to prepend
   `⚠ Quiet contract violated by host — answer body leaked above…`
   when it has already emitted any body content in the same turn. The
   2-line summary remains canonical; the warning makes the leak
   visible to the user (and to future benchmarks) instead of silent.

## Verification

Side-loaded into the installed plugin path and re-ran a "describe in
one paragraph" canary task (the same prose-soliciting pattern that
leaked in baseline #2 task #6). Result:

```
⚠ Cost estimated — token counts were approximated, not measured.
✓ Pyramid MoA done — 3 subtasks, cost 1047.8 tw-units (vs 22225.0 always-T3 → 95.28% saved).
  Full report: …pyramid-runs\describe-anchoring-mechanism-20260424-072856.md
  (Answer body suppressed — pass --output=normal to see it here.)
```

Quiet contract honored. No body leak. The new third line is visible to
the user as a permanent reminder. 3 premium requests, 4m 54s, 95.28%
saved — within Baseline #2 norms.

The fix itself was developed via the pyramid pipeline (3-node DAG,
all accepted at tier 1, no escalations), so the dogfood path
exercises the patched aggregate template too.

## Out of scope

- B6 (orchestrator skipping dispatch entirely) — tracked in #6.
- Adversarial-task safety — tracked in #8.

## Notes

- No contract change beyond the new template line. Trace JSON shape
  is unchanged.
- `plugin.json` bumped 0.2.2 → 0.2.3.
- `CHANGELOG.md` entry prepended.
